### PR TITLE
Update golangci lint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.5
+FROM golang:1.13.1
 
 RUN apt-get -q update --fix-missing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -L https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 RUN apt-get -y install bzip2
 
 # golangci-lint
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.20.0
 
 # enable sticky bit on GOPATH to allow installing tools by go get
 RUN chmod o+u -R /go

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN curl -L https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 RUN apt-get -y install bzip2
 
 # golangci-lint
-RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.12
+RUN curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $GOPATH/bin v1.17.1
 
 # enable sticky bit on GOPATH to allow installing tools by go get
 RUN chmod o+u -R /go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.5
+FROM golang:1.12.5
 
 RUN apt-get -q update --fix-missing
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,15 +8,6 @@ RUN apt-get -y install zip
 # For cross-compilation for windows with cgo
 RUN apt-get -y install mingw-w64                            
 
-# Install gometalinter
-RUN curl -L https://git.io/vp6lP | sh                       
-
-# Install reviewdog
-RUN go get -u github.com/haya14busa/reviewdog/cmd/reviewdog 
-
-# Install dep
-RUN curl -L https://raw.githubusercontent.com/golang/dep/master/install.sh | sh 
-
 RUN apt-get -y install bzip2
 
 # golangci-lint


### PR DESCRIPTION
## Updates

- update go compiler to v.1.13.1
- update golangci-lint to v1.20.0